### PR TITLE
Added rule for Huffington Post

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -186,4 +186,21 @@ window.AD_DETECTOR_RULES = {
       },
     },
   ],
+  'washingtonpost.com': [
+    {
+      example: 'http://www.washingtonpost.com/sf/brand-connect/wp/enterprise/one-year-later-a-commitment-renewed/',
+      match: function() {
+        // TODO Can also check for WP Brand Connect in URL, "left title-bar", or in title
+        var elts = document.querySelectorAll('.bylines .byline .byline-title');
+        if (elts.length < 1) {
+          return false;
+        }
+        return elts[0].innerHTML.indexOf('Sponsor Generated Content') > -1;
+      },
+      getSponsor: function() {
+        // Uses images of sponsors' logos
+        return null;
+      }
+    }
+  ]
 };


### PR DESCRIPTION
Tested on two articles:
- [x] http://www.huffingtonpost.com/2014/07/24/things-you-never-knew-about-tequila_n_5589092.html
- [x] http://www.huffingtonpost.com/2014/07/09/latin-summer-food_n_5359280.html

Let me know if you find any articles that this rule does not work for.
