### PR TITLE
Added rules for Huffington Post and Washington Post

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -203,4 +203,21 @@ _window.AD_DETECTOR_RULES = {
       },
     },
   ],
+  'washingtonpost.com': [
+    {
+      example: 'http://www.washingtonpost.com/sf/brand-connect/wp/enterprise/one-year-later-a-commitment-renewed/',
+      match: function() {
+        // TODO Can also check for WP Brand Connect in URL, "left title-bar", or in title
+        var elts = document.querySelectorAll('.bylines .byline .byline-title');
+        if (elts.length < 1) {
+          return false;
+        }
+        return elts[0].innerHTML.indexOf('Sponsor Generated Content') > -1;
+      },
+      getSponsor: function() {
+        // Uses images of sponsors' logos
+        return null;
+      }
+    }
+  ]
 };


### PR DESCRIPTION
Tested on two articles for Huffington Post:
- [x] http://www.huffingtonpost.com/2014/07/24/things-you-never-knew-about-tequila_n_5589092.html
- [x] http://www.huffingtonpost.com/2014/07/09/latin-summer-food_n_5359280.html

And one article for Washington Post Brand Connect:
- [x] http://www.washingtonpost.com/sf/brand-connect/wp/enterprise/one-year-later-a-commitment-renewed/

Let me know if you find any articles that these rules do not work for.
