### PR TITLE
Rule for Danish politiken.dk

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -679,6 +679,13 @@ _window.AD_DETECTOR_RULES = {
       match: function() {
         return urlContains('/annoncesektion/');
       },
+      getSponsor: function() {
+        var paidElts = document.getElementsByClassName('disclaimer');
+        if (paidElts.length < 1) {
+          return null;
+        }
+        return paidElts[0].innerHTML.replace('Annoncørindhold fra ', '');
+      },
     },
   ],
   'prnewswire.com': [


### PR DESCRIPTION
Linkified example: http://politiken.dk/annoncesektion/ibm/ECE2192847/digital-bodyguard-beskytter-mod-identitetstyveri/.

Thanks for a great extension. :)
