### PR TITLE
Keep Daily Beast from warning about infinite-scroll-loaded articles.

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -830,12 +830,12 @@ _window.AD_DETECTOR_RULES = {
   ],
   'thedailybeast.com': [
     {
-      example: 'http://www.thedailybeast.com/articles/2014/05/29/will-you-choose-a-conflict-free-microprocessor.html',
+      example: 'http://www.thedailybeast.com/articles/2014/09/30/how-we-compute-flexible-hardware-required.html',
       match: function() {
-        return selectorAppears('article .partnerad');
+        return selectorAppears('article[data-index='1'] .partnerad');
       },
       getSponsor: function() {
-        return document.querySelector('.article-main-content .section').textContent;
+        return document.querySelector('article[data-index="1"] .article-main-content .section').textContent;
       },
     }
   ],


### PR DESCRIPTION
The sponsor detection is probably worthless at this point - the example I uploaded is sponsored by Lenovo, but it uses the category name as the sponsor, even though that category has both articles and native advertising. The original example disclosed the sponsor in the category, but the new example doesn't. In fact, for Lenovo ads, the only consistent thing I could see is that there's a Lenovo logo in there, but it's an image with alt tag "lenovo-inline-from", which is inconsistently placed, and not a reliable method of sponsor detection.

Also, this is a bit of a hack, in that we're intentionally silencing warnings about infinitely-scrolled content. The underlying issue is that when you request a page from Daily Beast, they're actually loading three or four other articles which may or may not be native advertising. I do not believe we have APIs for this.
