### PR TITLE
Update rule for theguardian.com

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -892,7 +892,7 @@ _window.AD_DETECTOR_RULES = {
     {
       example: 'http://www.theguardian.com/sustainable-business/2014/jul/18/ben-jerry-turn-ice-cream-into-energy',
       match: function() {
-        return selectorAppears('meta[property="article:tag"][content*="Partner zone"]');
+        return selectorAppears('meta[property="article:tag"][content*="partner zone"]');
       },
     }
   ],


### PR DESCRIPTION
Lower case value is now used in the meta tag.