### PR TITLE
Removed imperfect getSponsor() for buzzfeed.com

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -139,6 +139,7 @@ _window.AD_DETECTOR_RULES = {
         }
         return false;
       },
+    },
   ],
   'businessinsider.com': [
     {

--- a/src/rules.js
+++ b/src/rules.js
@@ -131,7 +131,7 @@ _window.AD_DETECTOR_RULES = {
   ],
   'buzzfeed.com': [
     {
-      example: 'http://www.buzzfeed.com/bravo/ways-to-up-your-online-dating-game',
+      example: 'http://www.buzzfeed.com/veronica0811/10-fast-growing-slack-communitieshangouts-you-sho-nvja',
       match: function() {
         var elts = document.getElementsByClassName('byline__title');
         if (elts.length > 0) {
@@ -139,14 +139,6 @@ _window.AD_DETECTOR_RULES = {
         }
         return false;
       },
-      getSponsor: function() {
-        var elts = document.getElementsByClassName('byline__author');
-        if (elts.length > 0) {
-          return elts[0].innerHTML.trim();
-        }
-        return null;
-      },
-    },
   ],
   'businessinsider.com': [
     {


### PR DESCRIPTION
Function didn’t work on <http://www.buzzfeed.com/veronica0811/10-fast-growing-slack-communitieshangouts-you-sho-nvja>.

I guess the brand is sometimes listed as the author of the article, but not always. Given the somewhat clear emphasis on branded content, I think it’s fine to just notify people that they are viewing native advertising, but I want to hear others sign off on it, before I commit it to `master`.